### PR TITLE
Stubbing /oauth2 as provided by profiles

### DIFF
--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -7,6 +7,7 @@ use JDesrosiers\Silex\Provider\CorsServiceProvider;
 use Negotiation\Accept;
 use Silex\Application;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -1993,6 +1994,35 @@ $app->get('/subjects/{id}', function (Request $request, string $id) use ($app) {
         Response::HTTP_OK,
         ['Content-Type' => sprintf('%s; version=%s', $type, $version)]
     );
+});
+
+$app->get('/oauth2/authorize', function (Request $request) {
+    $redirectUri = $request->get('redirect_uri');
+    $state = $request->get('state');
+    $code = 'code_'.$state;
+    $location = $redirectUri.'?'.http_build_query([
+        'code' => $code,
+        'state' => $state,
+    ]);
+
+    return new Response(
+        'pong',
+        Response::HTTP_FOUND,
+        [
+            'Location' => $location,
+        ]
+    );
+});
+
+$app->post('/oauth2/token', function (Request $request) {
+    $code = $request->get('code');
+
+    return new JsonResponse([
+        'access_token' => 'access_token_'.$code,
+        'token_type' => 'bearer',
+        'expires_in' => 30 * 24 * 60 * 60,
+        'scope' => '/authenticate',
+    ]);
 });
 
 $app->get('ping', function () use ($app) {

--- a/test/OAuth2Test.php
+++ b/test/OAuth2Test.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace test\eLife\DummyApi;
+
+use PHPUnit_Framework_TestCase;
+use Silex\Application;
+use Symfony\Component\HttpFoundation\Request;
+
+final class OAuth2Test extends PHPUnit_Framework_TestCase
+{
+    private $app;
+
+    /**
+     * @before
+     */
+    final public function setUpApp()
+    {
+        $this->app = require __DIR__.'/../src/bootstrap.php';
+    }
+
+    final protected function getApp() : Application
+    {
+        return $this->app;
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_authorize_a_user()
+    {
+        $response = $this->getApp()->handle(Request::create(
+            '/oauth2/authorize',
+            'GET',
+            [
+                'response_type' => 'code',
+                'client_id' => 'journal',
+                'state' => 'unique_state_string',
+                'redirect_uri' => 'https://example.com/check',
+            ]
+        ));
+
+        $this->assertSame(
+            302,
+            $response->getStatusCode(),
+            var_export($response->getContent(), true)
+        );
+        $this->assertSame(
+            'https://example.com/check?code=code_unique_state_string&state=unique_state_string',
+            $response->headers->get('Location')
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_release_a_token()
+    {
+        $response = $this->getApp()->handle(Request::create(
+            '/oauth2/token',
+            'POST',
+            [
+                'client_id' => 'journal',
+                'client_secret' => 'journal_secret',
+                'redirect_uri' => 'https://example.com/check',
+                'grant_type' => 'authorization_code',
+                'code' => 'code_unique_string',
+            ]
+        ));
+
+        $this->assertSame(
+            200,
+            $response->getStatusCode(),
+            var_export($response->getContent(), true)
+        );
+        $this->assertSame(
+            [
+                'access_token' => 'access_token_code_unique_string',
+                'token_type' => 'bearer',
+                'expires_in' => 30 * 24 * 60 * 60,
+                'scope' => '/authenticate',
+            ],
+            json_decode($response->getContent(), true)
+        );
+    }
+}


### PR DESCRIPTION
We need journal to be able to reliably run with an api-dummy in place of the api-gateway, for development and testing purposes. /oauth2 is part of the api-gateway even if it's not part of api-raml. Therefore, it should be implemented here