### PR TITLE
Container using php built-in webserver

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+build/
+.git
+Jenkinsfile
+vendor/
+*.md
+*.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM elifesciences/php_cli
+
+USER root
+RUN mkdir /srv/api-dummy && chown elife:elife /srv/api-dummy
+
+USER elife
+WORKDIR /srv/api-dummy
+COPY composer.json composer.lock /srv/api-dummy/
+RUN composer install
+COPY . /srv/api-dummy
+
+USER www-data
+EXPOSE 8080
+CMD ["php", "-S", "0.0.0.0:8080", "-t", "web/"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir /srv/api-dummy && chown elife:elife /srv/api-dummy
 USER elife
 WORKDIR /srv/api-dummy
 COPY composer.json composer.lock /srv/api-dummy/
-RUN composer install
+RUN composer install --classmap-authoritative --no-dev
 COPY . /srv/api-dummy
 
 USER www-data


### PR DESCRIPTION
It's a single process, but for testing purposes it may be enough and provides a portable dummy service without the need for an nginx container as well.

Here answering to 100 concurrent requests (one at a time) in 1.5 seconds:
```
$ time cat 100.txt | xargs -P
 5 -I {} curl -s localhost:8080/ping ;
pongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpongpong
real    0m1.527s
user    0m0.328s
sys     0m0.205s
```