### PR TITLE
Add missing checkout in workspace

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,6 +34,7 @@ elifePipeline {
 
     elifeMainlineOnly {
         stage 'Deploy on demo', {
+            checkout scm
             elifeGitMoveToBranch commit, 'master'
             elifeOnNode(
                 {


### PR DESCRIPTION
To be able to push the commit to `master`, the Jenkins workspace needs to have a local .git repository. This is cloned before in the pipeline, but on the separate node that runs containers.