### PR TITLE
Add reviewed-preprints to the /search endpoint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     },
     "require": {
         "php": "^7.0",
+        "elife/api": "dev-feature/reviewed-preprint-compiled",
         "elife/api-problem": "^1.0",
         "elife/content-negotiator": "^1.0",
         "elife/ping": "^1.0",
@@ -24,7 +25,6 @@
         "symfony/http-kernel": "^3.1"
     },
     "require-dev": {
-        "elife/api": "^2.0",
         "elife/api-client": "^1.0@dev",
         "elife/api-validator": "^1.0@dev",
         "guzzlehttp/guzzle": "^6.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a1c915c570f68ee3b098826111a3701a",
+    "content-hash": "02f4e9e3e78025739097881d34453ec3",
     "packages": [
         {
             "name": "crell/api-problem",
@@ -59,6 +59,31 @@
                 "xml"
             ],
             "time": "2018-11-24T19:56:22+00:00"
+        },
+        {
+            "name": "elife/api",
+            "version": "dev-feature/reviewed-preprint-compiled",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/elifesciences/api-raml.git",
+                "reference": "384e6352516c0cdc890db611edbcd284647f919b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/elifesciences/api-raml/zipball/384e6352516c0cdc890db611edbcd284647f919b",
+                "reference": "384e6352516c0cdc890db611edbcd284647f919b",
+                "shasum": ""
+            },
+            "conflict": {
+                "justinrainbow/json-schema": "<3.0.0"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "eLife Sciences API specification",
+            "time": "2022-08-05T06:25:21+00:00"
         },
         {
             "name": "elife/api-problem",
@@ -544,6 +569,7 @@
                     "type": "tidelift"
                 }
             ],
+            "abandoned": "symfony/error-handler",
             "time": "2020-10-24T10:57:07+00:00"
         },
         {
@@ -852,12 +878,12 @@
                 }
             },
             "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
                 "psr-4": {
                     "Symfony\\Polyfill\\Ctype\\": ""
-                }
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -924,12 +950,12 @@
                 }
             },
             "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
                 "psr-4": {
                     "Symfony\\Polyfill\\Mbstring\\": ""
-                }
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1055,12 +1081,12 @@
                 }
             },
             "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
                 "psr-4": {
                     "Symfony\\Polyfill\\Php70\\": ""
                 },
+                "files": [
+                    "bootstrap.php"
+                ],
                 "classmap": [
                     "Resources/stubs"
                 ]
@@ -1312,12 +1338,12 @@
             },
             "type": "library",
             "autoload": {
-                "files": [
-                    "lib/Assert/functions.php"
-                ],
                 "psr-4": {
                     "Assert\\": "lib/Assert"
-                }
+                },
+                "files": [
+                    "lib/Assert/functions.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1465,31 +1491,6 @@
                 "instantiate"
             ],
             "time": "2015-06-14T21:17:01+00:00"
-        },
-        {
-            "name": "elife/api",
-            "version": "2.5.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/elifesciences/api-raml.git",
-                "reference": "fbfd26f96e1f8d5bd80c4bf7314665fe5de5fa74"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/api-raml/zipball/fbfd26f96e1f8d5bd80c4bf7314665fe5de5fa74",
-                "reference": "fbfd26f96e1f8d5bd80c4bf7314665fe5de5fa74",
-                "shasum": ""
-            },
-            "conflict": {
-                "justinrainbow/json-schema": "<3.0.0"
-            },
-            "type": "library",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "eLife Sciences API specification",
-            "time": "2021-10-05T12:24:35+00:00"
         },
         {
             "name": "elife/api-client",
@@ -3797,6 +3798,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
+        "elife/api": 20,
         "elife/api-client": 20,
         "elife/api-validator": 20
     },

--- a/data/reviewed-preprint/19560.json
+++ b/data/reviewed-preprint/19560.json
@@ -1,5 +1,5 @@
 {
-  "type": "reviewed-preprints",
+  "type": "reviewed-preprint",
   "status": "reviewed",
   "id": "19560",
   "version": 1,

--- a/data/reviewed-preprints/19560.json
+++ b/data/reviewed-preprints/19560.json
@@ -1,0 +1,43 @@
+{
+  "type": "reviewed-preprints",
+  "status": "reviewed",
+  "id": "19560",
+  "version": 1,
+  "doi": "10.7554/eLife.19560",
+  "authorLine": "Lee R Berger et al.",
+  "title": "<i>Homo naledi</i>, a new species of the genus <i>Homo</i> from the Dinaledi Chamber, South Africa",
+  "titlePrefix": "Title prefix",
+  "stage": "published",
+  "published": "2022-08-01T00:00:00Z",
+  "statusDate": "2022-08-01T00:00:00Z",
+  "volume": 4,
+  "elocationId": "e19560",
+  "pdf": "https://elifesciences.org/content/4/e19560.pdf",
+  "subjects": [
+    {
+      "id": "genomics-evolutionary-biology",
+      "name": "Genomics and Evolutionary Biology"
+    }
+  ],
+  "curationLabels": ["Ground-breaking", "Convincing"],
+  "impactStatement": "A new hominin species has been unearthed in the Dinaledi Chamber of the Rising Star cave system in the largest assemblage of a single species of hominins yet discovered in Africa.",
+  "image": {
+    "thumbnail": {
+      "uri": "https://iiif.elifesciences.org/lax/19560%2Felife-19560-fig1-v1.tif",
+      "alt": "",
+      "source": {
+        "mediaType": "image/jpeg",
+        "uri": "https://iiif.elifesciences.org/lax/19560%2Felife-19560-fig1-v1.tif/full/full/0/default.jpg",
+        "filename": "an-image.jpg"
+      },
+      "size": {
+        "width": 4194,
+        "height": 4714
+      },
+      "focalPoint": {
+        "x": 25,
+        "y": 75
+      }
+    }
+  }
+}

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -2224,7 +2224,7 @@ $app->get('/search', function (Request $request, Accept $type) use ($app) {
         $headers
     );
 })->before($app['negotiate.accept'](
-//    'application/vnd.elife.search+json; version=2', TODO: somehow doesn't allow the tests pass! Need to discuss.
+    'application/vnd.elife.search+json; version=2',
     'application/vnd.elife.search+json; version=1'
 ));
 

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -2224,7 +2224,7 @@ $app->get('/search', function (Request $request, Accept $type) use ($app) {
         $headers
     );
 })->before($app['negotiate.accept'](
-    'application/vnd.elife.search+json; version=2',
+//    'application/vnd.elife.search+json; version=2', TODO: somehow doesn't allow the tests pass! Need to discuss.
     'application/vnd.elife.search+json; version=1'
 ));
 

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -114,8 +114,8 @@ $app['bioprotocols'] = function () {
     return $bioprotocols;
 };
 
-$app['reviewed-preprints'] = function () use ($app) {
-    $finder = (new Finder())->files()->name('*.json')->in(__DIR__.'/../data/reviewed-preprints');
+$app['reviewed-preprint'] = function () use ($app) {
+    $finder = (new Finder())->files()->name('*.json')->in(__DIR__ . '/../data/reviewed-preprint');
 
     $preprints = [];
     foreach ($finder as $file) {
@@ -2034,11 +2034,22 @@ $app->get('/search', function (Request $request, Accept $type) use ($app) {
         $results[] = $result;
     }
 
-    foreach ($app['reviewed-preprints'] as $result) {
-        $result['_search'] = strtolower(json_encode($result));
-        //TODO: Not sure about which date to take!
-        $result['_sort_date'] = DateTimeImmutable::createFromFormat(DATE_ATOM, $result['published']);
-        $results[] = $result;
+    $contentTypes = [
+        'blog-article',
+        'collection',
+        'labs-post',
+        'interview',
+        'podcast-episode',
+    ];
+
+    if ($type->getParameter('version') === "2") {
+        foreach ($app['reviewed-preprint'] as $result) {
+            $result['_search'] = strtolower(json_encode($result));
+            //TODO: Not sure about which date to take!
+            $result['_sort_date'] = DateTimeImmutable::createFromFormat(DATE_ATOM, $result['published']);
+            $results[] = $result;
+        }
+        $contentTypes[] = 'reviewed-preprint';
     }
 
     foreach ($app['blog-articles'] as $result) {
@@ -2149,16 +2160,7 @@ $app->get('/search', function (Request $request, Accept $type) use ($app) {
         }));
     }
 
-    foreach (
-        [
-            'blog-article',
-            'collection',
-            'labs-post',
-            'interview',
-            'podcast-episode',
-            'reviewed-preprints',
-        ] as $contentType
-    ) {
+    foreach ($contentTypes as $contentType) {
         $allTypes[$contentType] = count(array_filter($results, function ($result) use ($contentType) {
             return $contentType === $result['type'];
         }));

--- a/test/SmokeTest.php
+++ b/test/SmokeTest.php
@@ -460,21 +460,24 @@ final class SmokeTest extends PHPUnit_Framework_TestCase
                 'application/vnd.elife.subject+json; version=1',
             ];
         }
-
+        yield $path = '/search?type[]=reviewed-preprint' => [
+            $this->createRequest($path, 'application/vnd.elife.search+json; version=2'),
+            'application/vnd.elife.search+json; version=2'
+        ];
         yield $path = '/search' => [
-            $this->createRequest($path),
-            'application/vnd.elife.search+json; version=1',
+            $this->createRequest($path, 'application/vnd.elife.search+json; version=1'),
+            'application/vnd.elife.search+json; version=1'
         ];
         yield $path = '/search?for=cell' => [
-            $this->createRequest($path),
+            $this->createRequest($path, 'application/vnd.elife.search+json; version=1'),
             'application/vnd.elife.search+json; version=1',
         ];
         yield $path = '/search?subject[]=cell-biology' => [
-            $this->createRequest($path),
+            $this->createRequest($path, 'application/vnd.elife.search+json; version=1'),
             'application/vnd.elife.search+json; version=1',
         ];
         yield $path = '/search?start-date=2017-01-01&end-date=2017-01-01' => [
-            $this->createRequest($path),
+            $this->createRequest($path,'application/vnd.elife.search+json; version=1'),
             'application/vnd.elife.search+json; version=1',
         ];
         yield $path = '/search?start-date=2017-02-29' => [
@@ -492,6 +495,32 @@ final class SmokeTest extends PHPUnit_Framework_TestCase
             'application/problem+json',
             400,
         ];
+    }
+
+    /**
+     * @test
+     */
+    public function search_v2_has_reviewed_preprint()
+    {
+        $request = $this->createRequest('/search?type[]=reviewed-preprint', 'application/vnd.elife.search+json;version=2');
+        $response = $this->getApp()->handle($request);
+        $content = json_decode($response->getContent(), true);
+        $this->assertEquals(19560, $content['items'][0]['id']);
+        foreach ($content['items'] as $item) {
+            $this->assertEquals("reviewed-preprint", $item['type']);
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function search_v1_does_not_have_reviewed_preprint()
+    {
+        $request = $this->createRequest('/search?type[]=reviewed-preprint', 'application/vnd.elife.search+json; version=1');
+        $response = $this->getApp()->handle($request);
+        $content = json_decode($response->getContent(), true);
+        $this->assertArrayNotHasKey("reviewed-preprint", $content['types']);
+        $this->assertEquals(0, $content['total']);
     }
 
     private function createRequest(string $uri, string $type = '*/*') : Request


### PR DESCRIPTION
Hi @nlisgo,

we found the issue regarding the tests. Somehow the new version that we added to the `/search` endpoint doesn't allow other tests to pass. I removed the line, but I'm not sure that would be the best approach. Please advise if more changes are needed.

Thank you